### PR TITLE
Removed version constrain in debians

### DIFF
--- a/ublox/debian/changelog
+++ b/ublox/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox (1.5.0-greenzie-focal2) focal; urgency=medium
+
+  * Removed version constraint
+
+ -- Kristian Kabbabe <kristian@greenzie.com>  Wed, 11 May 2022 12:17:33 -0400
+
 ros-noetic-ublox (1.5.0-greenzie-focal1) focal; urgency=medium
 
   * Debianize

--- a/ublox/debian/control
+++ b/ublox/debian/control
@@ -11,8 +11,8 @@ Package: ros-noetic-ublox
 Architecture: any
 Depends: ${shlibs:Depends},
     ${misc:Depends},
-    ros-noetic-ublox-gps (= ${binary:Version}),
-    ros-noetic-ublox-msgs (= ${binary:Version}),
-    ros-noetic-ublox-msg-filters (= ${binary:Version}),
-    ros-noetic-ublox-serialization (= ${binary:Version})
+    ros-noetic-ublox-gps,
+    ros-noetic-ublox-msgs,
+    ros-noetic-ublox-msg-filters,
+    ros-noetic-ublox-serialization
 Description: Provides a ublox_gps node for u-blox GPS receivers, messages, and serialization packages for the binary UBX protocol.

--- a/ublox_gps/debian/changelog
+++ b/ublox_gps/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox-gps (1.5.0-greenzie-focal3) focal; urgency=medium
+
+  * Removed version constraint
+
+ -- Kristian Kabbabe <kristian@greenzie.com>  Wed, 11 May 2022 12:16:56 -0400
+
 ros-noetic-ublox-gps (1.5.0-greenzie-focal2) focal; urgency=medium
 
   * Creating service for GPS device version info. 

--- a/ublox_gps/debian/control
+++ b/ublox_gps/debian/control
@@ -9,8 +9,8 @@ Build-Depends: debhelper (>= 9.0.0),
     ros-noetic-roscpp-serialization,
     ros-noetic-rtcm-msgs,
     ros-noetic-tf,
-    ros-noetic-ublox-msgs (= ${binary:Version}),
-    ros-noetic-ublox-serialization (= ${binary:Version})
+    ros-noetic-ublox-msgs,
+    ros-noetic-ublox-serialization
 Homepage: http://ros.org/wiki/ublox
 Standards-Version: 3.9.2
 
@@ -23,6 +23,6 @@ Depends: ${shlibs:Depends},
     ros-noetic-roscpp-serialization,
     ros-noetic-rtcm-msgs,
     ros-noetic-tf,
-    ros-noetic-ublox-msgs (= ${binary:Version}),
-    ros-noetic-ublox-serialization (= ${binary:Version})
+    ros-noetic-ublox-msgs,
+    ros-noetic-ublox-serialization
 Description: Driver for u-blox GPS devices.

--- a/ublox_msg_filters/debian/changelog
+++ b/ublox_msg_filters/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox-msg-filters (1.5.0-greenzie-focal2) focal; urgency=medium
+
+  * Removed version constraint
+
+ -- Kristian Kabbabe <kristian@greenzie.com>  Wed, 11 May 2022 12:17:15 -0400
+
 ros-noetic-ublox-msg-filters (1.5.0-greenzie-focal1) focal; urgency=medium
 
   * Debianize

--- a/ublox_msg_filters/debian/control
+++ b/ublox_msg_filters/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9.0.0),
     ros-noetic-roscpp,
     ros-noetic-roslaunch,
     ros-noetic-rospy,
-    ros-noetic-ublox-msgs (= ${binary:Version})
+    ros-noetic-ublox-msgs
 Homepage: http://ros.org/wiki/ublox
 Standards-Version: 3.9.2
 
@@ -17,5 +17,5 @@ Architecture: any
 Depends: ${shlibs:Depends},
     ${misc:Depends},
     ros-noetic-message-filters,
-    ros-noetic-ublox-msgs (= ${binary:Version})
+    ros-noetic-ublox-msgs
 Description: Time synchronize multiple uBlox messages to get a single callback

--- a/ublox_msgs/debian/changelog
+++ b/ublox_msgs/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox-msgs (1.5.0-greenzie-focal2) focal; urgency=medium
+
+  * Removed version constraint
+
+ -- Kristian Kabbabe <kristian@greenzie.com>  Wed, 11 May 2022 12:17:21 -0400
+
 ros-noetic-ublox-msgs (1.5.0-greenzie-focal1) focal; urgency=medium
 
   * Debianize

--- a/ublox_msgs/debian/control
+++ b/ublox_msgs/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9.0.0),
     ros-noetic-message-generation,
     ros-noetic-sensor-msgs,
     ros-noetic-std-msgs,
-    ros-noetic-ublox-serialization (= ${binary:Version})
+    ros-noetic-ublox-serialization
 Homepage: http://ros.org/wiki/ublox
 Standards-Version: 3.9.2
 
@@ -18,5 +18,5 @@ Depends: ${shlibs:Depends},
     ros-noetic-message-runtime,
     ros-noetic-sensor-msgs,
     ros-noetic-std-msgs,
-    ros-noetic-ublox-serialization (= ${binary:Version})
+    ros-noetic-ublox-serialization
 Description: ublox_msgs contains raw messages for u-blox GNSS devices.

--- a/ublox_serialization/debian/changelog
+++ b/ublox_serialization/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox-serialization (1.5.0-greenzie-focal2) focal; urgency=medium
+
+  * Removed version constraint
+
+ -- Kristian Kabbabe <kristian@greenzie.com>  Wed, 11 May 2022 12:17:26 -0400
+
 ros-noetic-ublox-serialization (1.5.0-greenzie-focal1) focal; urgency=medium
 
   * Debianize


### PR DESCRIPTION
Removing version constrain from debian/control as if we don't then we would have to release ALL debians  everytime there is a bump change.