### PR TITLE
Jonathansanabria/ublox rename version service to leverage/sc 21949

### DIFF
--- a/ublox_gps/debian/changelog
+++ b/ublox_gps/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-ublox-gps (1.5.0-greenzie-focal4) focal; urgency=medium
+
+  * Updating service name to poll_version.
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Thu, 16 Jun 2022 20:43:35 -0400
+
 ros-noetic-ublox-gps (1.5.0-greenzie-focal3) focal; urgency=medium
 
   * Removed version constraint

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -657,7 +657,7 @@ void UbloxNode::initialize()
   // Params must be set before initializing IO
   getRosParams();
   initializeIo();
-  ros::ServiceServer service = nh->advertiseService("poll_gps_version", &UbloxNode::getVersionInfo, this);
+  ros::ServiceServer service = nh->advertiseService("poll_version", &UbloxNode::getVersionInfo, this);
   // Must process Mon VER before setting firmware/hardware params
   processMonVer();
   if (protocol_version_ <= 14)


### PR DESCRIPTION
Updating service to `poll_version` because the node is already in the gps namespace.